### PR TITLE
Update for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
   "name": "lbadger/illuminate-data-migrations",
   "description": "Data Migrations for Laravel",
   "require": {
-    "illuminate/support": "5.4.*",
-    "illuminate/database": "5.4.*"
+    "illuminate/support": "~5.5",
+    "illuminate/database": "~5.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Console/DataMigrations/InstallCommand.php
+++ b/src/Console/DataMigrations/InstallCommand.php
@@ -47,7 +47,7 @@ class InstallCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->repository->setSource($this->input->getOption('database'));
 

--- a/src/Console/DataMigrations/MigrateCommand.php
+++ b/src/Console/DataMigrations/MigrateCommand.php
@@ -53,7 +53,7 @@ class MigrateCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -58,7 +58,7 @@ class MigrateMakeCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -4,7 +4,7 @@ namespace Lbadger\Database\Console\DataMigrations;
 
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
-use Illuminate\Filesystem;
+use Illuminate\Filesystem\Filesystem;
 
 class MigrateMakeCommand extends BaseCommand
 {

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -51,7 +51,6 @@ class MigrateMakeCommand extends BaseCommand
 
         $this->creator = $creator;
         $this->composer = $composer;
-
     }
 
     /**
@@ -116,6 +115,5 @@ class MigrateMakeCommand extends BaseCommand
         }
 
         return parent::getMigrationPath();
-
     }
 }

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -4,6 +4,7 @@ namespace Lbadger\Database\Console\DataMigrations;
 
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Filesystem;
 
 class MigrateMakeCommand extends BaseCommand
 {
@@ -39,6 +40,13 @@ class MigrateMakeCommand extends BaseCommand
     protected $composer;
 
     /**
+     * The Filesystem instance.
+     *
+     * @var Filesystem
+     */
+    protected $files;
+
+    /**
      * Create a new migration install command instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
@@ -51,6 +59,7 @@ class MigrateMakeCommand extends BaseCommand
 
         $this->creator = $creator;
         $this->composer = $composer;
+        $this->files = new Filesystem();
     }
 
     /**
@@ -110,10 +119,13 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function getMigrationPath()
     {
+        $path = parent::getMigrationPath();
         if (! is_null($targetPath = $this->input->getOption('path'))) {
-            return $this->laravel->basePath().'/'.$targetPath;
+            $path = $this->laravel->basePath().'/'.$targetPath;
         }
 
-        return parent::getMigrationPath();
+        if (! $this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        }
     }
 }

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -127,5 +127,7 @@ class MigrateMakeCommand extends BaseCommand
         if (! $this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0777, true, true);
         }
+
+        return $path;
     }
 }

--- a/src/Console/DataMigrations/MigrateMakeCommand.php
+++ b/src/Console/DataMigrations/MigrateMakeCommand.php
@@ -4,7 +4,6 @@ namespace Lbadger\Database\Console\DataMigrations;
 
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
-use Illuminate\Filesystem\Filesystem;
 
 class MigrateMakeCommand extends BaseCommand
 {
@@ -40,13 +39,6 @@ class MigrateMakeCommand extends BaseCommand
     protected $composer;
 
     /**
-     * The Filesystem instance.
-     *
-     * @var Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new migration install command instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
@@ -59,7 +51,7 @@ class MigrateMakeCommand extends BaseCommand
 
         $this->creator = $creator;
         $this->composer = $composer;
-        $this->files = new Filesystem();
+
     }
 
     /**
@@ -119,15 +111,11 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function getMigrationPath()
     {
-        $path = parent::getMigrationPath();
         if (! is_null($targetPath = $this->input->getOption('path'))) {
-            $path = $this->laravel->basePath().'/'.$targetPath;
+            return $this->laravel->basePath().'/'.$targetPath;
         }
 
-        if (! $this->files->isDirectory(dirname($path))) {
-            $this->files->makeDirectory(dirname($path), 0777, true, true);
-        }
+        return parent::getMigrationPath();
 
-        return $path;
     }
 }

--- a/src/Console/DataMigrations/RefreshCommand.php
+++ b/src/Console/DataMigrations/RefreshCommand.php
@@ -29,7 +29,7 @@ class RefreshCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Console/DataMigrations/ResetCommand.php
+++ b/src/Console/DataMigrations/ResetCommand.php
@@ -49,7 +49,7 @@ class ResetCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Console/DataMigrations/RollbackCommand.php
+++ b/src/Console/DataMigrations/RollbackCommand.php
@@ -49,7 +49,7 @@ class RollbackCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Console/DataMigrations/StatusCommand.php
+++ b/src/Console/DataMigrations/StatusCommand.php
@@ -47,7 +47,7 @@ class StatusCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->migrator->setConnection($this->option('database'));
 


### PR DESCRIPTION
## Summary
These changes make this package compatible with Laravel 5.5. 

## New Release
Due to the change in the name of the fire method to handle, this change is not going to be backwards compatible so you should create a new release with 2.0.0 for the tag.